### PR TITLE
Use kankyo to load environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
+.env
 Cargo.lock
 config.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "showdown"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["mikopits <mikopits@gmail.com>"]
 license = "MIT"
 
 [dependencies]
 env_logger = "0.4.2"
+kankyo = "0.1.1"
 lazy_static = "0.2.8"
 log = "0.3.7"
 regex = "0.2.1"
@@ -18,7 +19,7 @@ toml = "0.4.0"
 websocket = "0.19.1"
 
 # Plugin dependencies
-chrono = { version = "0.3.1", features = ["rustc-serialize"] }
+chrono = { version = "0.3.0", features = ["rustc-serialize"] }
 csv = "0.15.0"
 rand = "0.3.15"
 rustc-serialize = "0.3.23"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Clone the repo, write your own plugins, run `cargo run`.
 See example configuration file, and example plugins provided in the plugin mod
 to get started.
 
+NOTE: The `config.toml` and `.env` files should be placed in the root directory
+of the project.
+
 Todos
 -----
 

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -1,0 +1,2 @@
+BOT_USERNAME=example_name
+BOT_PASSWORD=example_pass

--- a/examples/example_config.toml
+++ b/examples/example_config.toml
@@ -5,14 +5,6 @@ host = "sim.smogon.com"
 # The port over which you want to connect to the websocket.
 port = "8000"
 
-# The username your bot will use. Use a name you've registered.
-user = ""
-
-# The password for the above registered username.
-# Be careful about who sees this file.
-# TODO: load password from env
-pass = ""
-
 # The rate at which the bot will send messages.
 # Recommended value is 333 (3 messages per second).
 throttle_ms = 333

--- a/src/bin/bin.rs
+++ b/src/bin/bin.rs
@@ -1,10 +1,14 @@
 extern crate showdown;
 extern crate env_logger;
+extern crate kankyo;
 
 use showdown::{Bot, Plugin, plugin};
 
 #[cfg(not(test))]
 fn main() {
+    // Loads our '.env' file into std::env.
+    kankyo::load().unwrap();
+
     env_logger::init().unwrap();
 
     let b = Bot::new("config.toml").unwrap();

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -1,6 +1,7 @@
-use std::thread;
+﻿use std::thread;
 use std::time::Duration;
 use std::collections::{BTreeSet, HashMap};
+use std::env;
 use std::io::{Read, stdin};
 use std::path::Path;
 use std::sync::{Arc, Mutex, mpsc};
@@ -263,17 +264,23 @@ impl Bot {
     }
 
     pub fn login(&self, challstr: &str) -> ::Result<()> {
+        let (user, pass) = {
+            let u = env::var("BOT_USERNAME").unwrap();
+            let p = env::var("BOT_PASSWORD").unwrap();
+
+            (u, p)
+        };
         let client = ::reqwest::Client::new().unwrap();
-        let sanitized_user = &::helpers::sanitize(&self.config.user);
+        let sanitized_user = &::helpers::sanitize(&user);
 
         let mut params = HashMap::new();
-        if self.config.pass.is_empty() {
+        if pass.is_empty() {
             params.insert("act", "getassertion");
             params.insert("userid", sanitized_user);
         } else {
             params.insert("act", "login");
-            params.insert("name", &self.config.user);
-            params.insert("pass", &self.config.pass);
+            params.insert("name", &user);
+            params.insert("pass", &pass);
         }
         params.insert("challstr", challstr);
 
@@ -289,7 +296,7 @@ impl Bot {
         let v: Value = ::serde_json::from_str(&data_str)?;
         let assertion = v["assertion"].as_str().unwrap();
 
-        self.send(format!("|/trn {},0,{}", self.config.user, assertion));
+        self.send(format!("|/trn {},0,{}", user, assertion));
         Ok(())
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,10 +11,6 @@ pub struct Config {
     pub host: String,
     #[serde(default="default_port")]
     pub port: String,
-    #[serde(default="Default::default")]
-    pub user: String,
-    #[serde(default="Default::default")]
-    pub pass: String,
     #[serde(default="default_mps")]
     pub throttle_ms: u64,
     #[serde(default="Default::default")]


### PR DESCRIPTION
kankyo is a crate that unloads environment variables listed in the '.env' file into `std::env`, which can be accessed via `std::env::var` like other environmental variables.

This allows the user to separate sensitive login data from other data that is, perhaps, more generalised. However, this adds a dependency for something simple while continuing to use a 'config.toml' setup...is this worth it?

Lastly, additions were added to the README to specify the locations of the config and env files, `.env` to the .gitignore, and the version for the `chrono` dependency was fixed. I was receiving errors.